### PR TITLE
[Feat/7] 로그인, 약관 페이지 UI 구현

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export default function Login() {
   return (
     <div className='mx-auto flex min-h-screen w-full flex-col items-center justify-center gap-[5.5rem]'>
@@ -37,9 +39,12 @@ export default function Login() {
 
       {/* 약관, 개인정보 처리방침, 마케팅 수신 */}
       <div className='flex items-center gap-[6.25rem]'>
-        <button className='cursor-pointer text-[1rem] text-[#000000]'>
+        <Link
+          href='/login/tos'
+          className='cursor-pointer text-[1rem] text-[#000000]'
+        >
           서비스 이용 약관
-        </button>
+        </Link>
         <button className='cursor-pointer text-[1rem] text-[#000000]'>
           개인정보 처리방침
         </button>

--- a/src/app/login/tos/page.tsx
+++ b/src/app/login/tos/page.tsx
@@ -1,0 +1,95 @@
+export default function TOSPage() {
+  return (
+    <div className='mx-auto flex w-[66rem] min-w-[66rem] flex-col gap-[3.75rem]'>
+      {/* 로고 */}
+      <div className='mt-[3.75rem] flex h-[3.125rem] w-[6.25rem] items-center justify-center bg-[#D9D9D9]'>
+        로고
+      </div>
+
+      {/* 서비스 이용 약관 */}
+      <div className='flex flex-col gap-[3.125rem]'>
+        {/* 헤더 */}
+        <div className='flex flex-col gap-[1.25rem]'>
+          <div className='flex items-center gap-[1.25rem]'>
+            <button className='cursor-pointer border-none bg-transparent'>
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='28'
+                height='28'
+                viewBox='0 0 28 28'
+                fill='none'
+              >
+                <path
+                  d='M18 23L9 14L18 5.00001'
+                  stroke='black'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                />
+              </svg>
+            </button>
+
+            <span className='text-[1.5rem] font-bold'>서비스 이용 약관</span>
+          </div>
+
+          <p className='w-full border border-[#CDD0D5]' />
+        </div>
+
+        {/* 내용 */}
+        <div className='flex flex-col gap-[1.25rem] px-[0.5rem]'>
+          <p className='ml-[1.25rem] text-[1.25rem] font-bold'>
+            제 1장 내용내용내용
+          </p>
+
+          <div className='flex w-full flex-col gap-[3.75rem] rounded-[1.75rem] border border-[#CDD0D5] px-[2.5rem] py-[2.25rem]'>
+            {/* 1조 */}
+            <div className='flex flex-col gap-[1.25rem]'>
+              <div className='text-[1.125rem] font-bold text-[#1A1A1A]'>
+                제 1조 (내용내용)
+              </div>
+              <div className='line-height-[150%] flex flex-col gap-[1.25rem] px-[0.25rem] text-[1rem] text-[#464B53]'>
+                <div className='flex flex-col gap-[0.75rem]'>
+                  <p>1. 내용내용내용내용</p>
+                  <div className='flex flex-col gap-[0.75rem] px-[2.5rem]'></div>
+                </div>
+
+                <div className='flex flex-col gap-[0.75rem]'>
+                  <p>2. 내용내용내용내용</p>
+                  <div className='flex flex-col gap-[0.75rem] px-[2.5rem]'>
+                    <p>1. 내용내용내용내용</p>
+                    <p>2. 내용내용내용내용</p>
+                    <p>3. 내용내용내용내용</p>
+                    <p>4. 내용내용내용내용</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 2조 */}
+            <div className='flex flex-col gap-[1.25rem]'>
+              <div className='text-[1.125rem] font-bold text-[#1A1A1A]'>
+                제 2조 (내용내용)
+              </div>
+              <div className='line-height-[150%] flex flex-col gap-[1.25rem] px-[0.25rem] text-[1rem] text-[#464B53]'>
+                <div className='flex flex-col gap-[0.75rem]'>
+                  <p>1. 내용내용내용내용</p>
+                  <div className='flex flex-col gap-[0.75rem] px-[2.5rem]'></div>
+                </div>
+
+                <div className='flex flex-col gap-[0.75rem]'>
+                  <p>2. 내용내용내용내용</p>
+                  <div className='flex flex-col gap-[0.75rem] px-[2.5rem]'>
+                    <p>1. 내용내용내용내용</p>
+                    <p>2. 내용내용내용내용</p>
+                    <p>3. 내용내용내용내용</p>
+                    <p>4. 내용내용내용내용</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #7 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
로그인 페이지와 약관 페이지의 UI입니다.
로그인 페이지는 중앙 정렬이 되어있고, Navbar가 제거된 후 간격이 정확한지 확인하겠습니다.

## 첨부 자료
### 로그인
<img width="1079" height="1084" alt="스크린샷 2025-12-29 16 26 48" src="https://github.com/user-attachments/assets/bac3759c-d8b7-4ed5-8be3-aeb049356829" />

### 약관
<img width="1079" height="1084" alt="스크린샷 2025-12-29 16 26 52" src="https://github.com/user-attachments/assets/92aa65c6-0940-47a6-aefc-eace8be0867a" />
