### PR TITLE
[Fix/133] 텍스트형 포트폴리오 API 단일 호출 에러 해결

### DIFF
--- a/src/features/correction/hooks/useCorrectionState.ts
+++ b/src/features/correction/hooks/useCorrectionState.ts
@@ -25,6 +25,7 @@ import { mapToPdfActivityBlock, toPatchBody } from '@/services/correction';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useCorrectionNavbar } from '@/contexts/CorrectionNavbarContext';
+import { useAuthStore } from '@/store/useAuthStore';
 import {
   INITIAL_PDF_ACTIVITIES,
   PDF_CATEGORY_CHAR_LIMIT,
@@ -132,9 +133,18 @@ export function useCorrectionState(correctionId: string | undefined) {
   const [fileDeleteConfirmTarget, setFileDeleteConfirmTarget] =
     useState<FileDeleteConfirmTarget>(null);
 
+  const accessToken = useAuthStore((s) => s.accessToken);
   const { data: experiencesData } = useExperienceControllerGetExperiences(
     undefined,
-    { query: { enabled: step === 'portfolio' } },
+    {
+      query: {
+        // 토큰이 있을 때만 호출 (세션 복원 전 요청 시 401 방지)
+        enabled:
+          !!accessToken &&
+          step === 'portfolio' &&
+          selectedPortfolioType === 'text',
+      },
+    },
   );
   const experiencesList = experiencesData?.result ?? [];
   const textPortfolios = experiencesList.map((e) => ({


### PR DESCRIPTION
## 연관 이슈
- Closes #133

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
호출을 버튼 클릭 시점으로 바꾸고, accessToken이 채워진 이후에 호출하도록 수정했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-