### PR TITLE
[Fix/152] 첨삭 포트폴리오 카드에서 태그가 영어로 뜨는 현상을 해결

### DIFF
--- a/src/features/correction/hooks/useCorrectionState.ts
+++ b/src/features/correction/hooks/useCorrectionState.ts
@@ -147,7 +147,7 @@ export function useCorrectionState(correctionId: string | undefined) {
   const textPortfolios = portfoliosList.map((p) => ({
     id: String(p.id),
     title: p.name,
-    tag: p.hopeJob != null ? String(p.hopeJob) : '',
+    tag: getHopeJobLabel(p.hopeJob),
     date: p.createdAt.slice(0, 10),
   }));
 


### PR DESCRIPTION
## 연관 이슈
- Closes #152 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
첨삭 포트폴리오 카드에서 태그가 영어로 뜨는 현상을 해결했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-