### PR TITLE
[BUG/179] 포트폴리오 생성 후 chat 페이지로 진입하는 오류 수정

### DIFF
--- a/src/app/(main)/experience/settings/[id]/chat/page.tsx
+++ b/src/app/(main)/experience/settings/[id]/chat/page.tsx
@@ -71,6 +71,11 @@ function ExperienceSettingsChatContent() {
     }
   }, [id, router]);
 
+  const { data: experienceData } = useExperienceControllerGetExperience(
+    experienceId,
+    { query: { enabled: Number.isFinite(experienceId) } },
+  );
+
   const newExperienceScheduleRef = useRef<number | null>(null);
   const removeExperience = useExperienceStore(
     (state) => state.removeExperience,
@@ -84,10 +89,6 @@ function ExperienceSettingsChatContent() {
       '새로운 경험 정리',
   );
 
-  const { data: experienceData } = useExperienceControllerGetExperience(
-    experienceId,
-    { query: { enabled: Number.isFinite(experienceId) } },
-  );
   const experienceName = experienceData?.result?.name;
   const titleReady = experienceData?.result != null;
   const displayTitle = titleReady

--- a/src/app/(main)/experience/settings/[id]/layout.tsx
+++ b/src/app/(main)/experience/settings/[id]/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, usePathname, useRouter } from 'next/navigation';
 import {
   useExperienceControllerGetExperience,
   useExperienceControllerGetExperiences,
@@ -15,11 +15,15 @@ export default function ExperienceSettingsIdLayout({
 }) {
   const params = useParams();
   const router = useRouter();
+  const pathname = usePathname();
   const idParam = typeof params.id === 'string' ? params.id : '';
   const experienceId = idParam ? Number(idParam) : NaN;
 
-  const { data, isLoading: isListLoading, isFetched: isListFetched } =
-    useExperienceControllerGetExperiences();
+  const {
+    data,
+    isLoading: isListLoading,
+    isFetched: isListFetched,
+  } = useExperienceControllerGetExperiences();
 
   const {
     data: singleData,
@@ -32,6 +36,15 @@ export default function ExperienceSettingsIdLayout({
   const myIds = (data?.result ?? []).map((item) => item.id);
   const listIncludesId = myIds.includes(experienceId);
   const singleSucceeded = singleData?.result != null;
+  const status = singleData?.result?.status;
+  const isDone = status != null && String(status).toUpperCase() === 'DONE';
+  const isChatPath = pathname?.endsWith('/chat') ?? false;
+
+  /* DONE인 경험의 chat URL 진입 시 portfolio로 리다이렉트 */
+  useEffect(() => {
+    if (!idParam || !isChatPath || !singleSucceeded || !isDone) return;
+    router.replace(`/experience/settings/${idParam}/portfolio`);
+  }, [idParam, isChatPath, singleSucceeded, isDone, router]);
 
   useEffect(() => {
     if (!Number.isFinite(experienceId)) {
@@ -58,7 +71,8 @@ export default function ExperienceSettingsIdLayout({
   const isAllowed =
     !isInvalidId &&
     (listIncludesId || singleSucceeded) &&
-    (isListFetched && !isListLoading) &&
+    isListFetched &&
+    !isListLoading &&
     (listIncludesId || (isSingleFetched && !isSingleLoading));
 
   const showSpinner =
@@ -76,6 +90,13 @@ export default function ExperienceSettingsIdLayout({
 
   if (!isAllowed) {
     return null;
+  }
+
+  /* DONE인 경험의 chat 진입 시 리다이렉트 중에는 chat 미노출 */
+  if (isChatPath && isDone) {
+    return (
+      <div className='flex min-h-[50vh] items-center justify-center'></div>
+    );
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## 연관 이슈
- Closes #179 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
경험정리 대화 후 포트폴리오까지 생성했을 때에도 다시 chat페이지로 진입하는 현상을 수정했습니다.
status가 Done이면 chat페이지에 진입하지 않고 바로 portfolio페이지로 리다이렉트 합니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-