### PR TITLE
[BUG/205] 핫픽스 - ONCHAT 상태에서 createloading 페이지에 진입하는 문제

### DIFF
--- a/src/app/(main)/experience/settings/[id]/chat/page.tsx
+++ b/src/app/(main)/experience/settings/[id]/chat/page.tsx
@@ -8,6 +8,7 @@ import {
   isChatNewExperience,
   setExperienceReturnPath,
   hasCreateloadingEntered,
+  clearCreateloadingEntered,
 } from '@/features/experience/utils/experienceReturnPath';
 import { BackButton } from '@/components/BackButton';
 import { StepProgressBar } from '@/components/StepProgressBar';
@@ -66,14 +67,6 @@ function ExperienceSettingsChatContent() {
   const isNewExperience = searchParams.get('new') === '1';
   const experienceId = id ? Number(id) : NaN;
   const sessionAbortRef = useRef<AbortController | null>(null);
-
-  // createloading까지 진입한 경험은 chat 페이지로 되돌아오지 않도록 createloading으로 리다이렉트
-  useEffect(() => {
-    if (!id) return;
-    if (hasCreateloadingEntered(id)) {
-      router.replace(`/experience/settings/${id}/createloading`);
-    }
-  }, [id, router]);
 
   const { data: experienceData } = useExperienceControllerGetExperience(
     experienceId,
@@ -153,15 +146,21 @@ function ExperienceSettingsChatContent() {
       return;
     }
     const status = String(experience.status ?? '').toUpperCase();
-    if (status === 'ON_CHAT') return; // 이 페이지에 진입 허용
+    if (status === 'ON_CHAT') {
+      // 생성 로딩(createloading) 진입 플래그가 남아있어도, 실제 상태가 ON_CHAT이면 chat 진입이 맞음
+      clearCreateloadingEntered(id);
+      return; // 이 페이지에 진입 허용
+    }
     if (status === 'GENERATE' || status === 'GENERATE_FAILED') {
       router.replace(`/experience/settings/${id}/createloading`);
       return;
     }
     if (status === 'DONE') {
+      clearCreateloadingEntered(id);
       router.replace(`/experience/settings/${id}/portfolio`);
       return;
     }
+    clearCreateloadingEntered(id);
     router.replace('/experience');
   }, [id, experienceId, experienceData, router]);
 

--- a/src/features/experience/utils/experienceReturnPath.ts
+++ b/src/features/experience/utils/experienceReturnPath.ts
@@ -129,3 +129,12 @@ export function hasCreateloadingEntered(id: string): boolean {
   if (!id) return false;
   return getCreateloadingEnteredIds().has(id);
 }
+
+/* 해당 경험에 대해 createloading 진입 이력을 제거 */
+export function clearCreateloadingEntered(id: string): void {
+  if (!id) return;
+  const set = getCreateloadingEnteredIds();
+  if (!set.has(id)) return;
+  set.delete(id);
+  setCreateloadingEnteredIds(set);
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #205 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
createloading 페이지에 진입한 이력을 체크하고있고, ON_CHAT일 때는 반드시 chat페이지에 머물도록 하는 로직이 충돌되었습니다.
따라서 ON_CHAT일 때는 혹시나 createloading 페이지로 잘못 진입했을 경우, 진입한 이력을 무효화시켰습니다.
현재 상태에 맞는 페이지로 리다이렉트 되는 로직은 반영되어있기 때문에, 이 방식으로 해결했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-