### PR TITLE
[Feat/242] 첨삭 미존재 안내 문구 추가

### DIFF
--- a/src/features/correction/components/CorrectionResultActivityDetail.tsx
+++ b/src/features/correction/components/CorrectionResultActivityDetail.tsx
@@ -27,6 +27,18 @@ const buttonClass = (selected: boolean) =>
     ? 'border border-[#CDD0D5] bg-[#FFFFFF] text-[#5060C5]'
     : 'border border-[#E9EAEC] bg-[#E9EAEC] text-[#74777D]';
 
+function hasPortfolioOriginText(value: string | undefined | null): boolean {
+  return Boolean(value?.trim());
+}
+
+function EmptyActivityOriginMessage() {
+  return (
+    <div className='flex min-h-[15.375rem] w-full flex-1 items-center justify-center text-center text-[1rem] font-normal text-[#74777D]'>
+      첨삭할 내용이 존재하지 않아요.
+    </div>
+  );
+}
+
 function highlightText(text: string, lines: CorrectionLineItemReqDTO[] = [], activeFilter: 'reduce' | 'emphasize') {
   if (!text) return '';
   let result = text;
@@ -113,11 +125,15 @@ export function CorrectionResultActivityDetail({
           상세정보
         </div>
         <div className='flex gap-[1.5rem] rounded-[1.25rem] border border-[#74777D] px-[1.75rem] py-[2rem]'>
-          <div className='min-w-0 flex-1'>
-            {renderMarkdown(
-              portfolio.description,
-              correctionItem.description?.lines || [],
-              detailInfoButton === '축소 또는 제외' ? 'reduce' : 'emphasize'
+          <div className='min-h-[15.375rem] min-w-0 flex-1'>
+            {hasPortfolioOriginText(portfolio.description) ? (
+              renderMarkdown(
+                portfolio.description,
+                correctionItem.description?.lines || [],
+                detailInfoButton === '축소 또는 제외' ? 'reduce' : 'emphasize',
+              )
+            ) : (
+              <EmptyActivityOriginMessage />
             )}
           </div>
           <div className='w-[1px] flex-shrink-0 bg-[#9EA4A9]' />
@@ -151,11 +167,15 @@ export function CorrectionResultActivityDetail({
           담당업무
         </div>
         <div className='flex gap-[1.5rem] rounded-[1.25rem] border border-[#74777D] px-[1.75rem] py-[2rem]'>
-          <div className='min-h-[8rem] min-w-0 flex-1'>
-            {renderMarkdown(
-              portfolio.responsibilities,
-              correctionItem.responsibilities?.lines || [],
-              responsibilityButton === '축소 또는 제외' ? 'reduce' : 'emphasize'
+          <div className='min-h-[15.375rem] min-w-0 flex-1'>
+            {hasPortfolioOriginText(portfolio.responsibilities) ? (
+              renderMarkdown(
+                portfolio.responsibilities,
+                correctionItem.responsibilities?.lines || [],
+                responsibilityButton === '축소 또는 제외' ? 'reduce' : 'emphasize',
+              )
+            ) : (
+              <EmptyActivityOriginMessage />
             )}
           </div>
           <div className='w-[1px] flex-shrink-0 bg-[#9EA4A9]' />
@@ -189,11 +209,15 @@ export function CorrectionResultActivityDetail({
           문제 해결
         </div>
         <div className='flex gap-[1.5rem] rounded-[1.25rem] border border-[#74777D] px-[1.75rem] py-[2rem]'>
-          <div className='min-h-[8rem] min-w-0 flex-1'>
-            {renderMarkdown(
-              portfolio.problemSolving,
-              correctionItem.problemSolving?.lines || [],
-              problemSolvingButton === '축소 또는 제외' ? 'reduce' : 'emphasize'
+          <div className='min-h-[15.375rem] min-w-0 flex-1'>
+            {hasPortfolioOriginText(portfolio.problemSolving) ? (
+              renderMarkdown(
+                portfolio.problemSolving,
+                correctionItem.problemSolving?.lines || [],
+                problemSolvingButton === '축소 또는 제외' ? 'reduce' : 'emphasize',
+              )
+            ) : (
+              <EmptyActivityOriginMessage />
             )}
           </div>
           <div className='w-[1px] flex-shrink-0 bg-[#9EA4A9]' />
@@ -223,11 +247,15 @@ export function CorrectionResultActivityDetail({
           배운 점
         </div>
         <div className='flex gap-[1.5rem] rounded-[1.25rem] border border-[#74777D] px-[1.75rem] py-[2rem]'>
-          <div className='min-h-[8rem] min-w-0 flex-1'>
-            {renderMarkdown(
-              portfolio.learnings,
-              correctionItem.learnings?.lines || [],
-              lessonsButton === '축소 또는 제외' ? 'reduce' : 'emphasize'
+          <div className='min-h-[15.375rem] min-w-0 flex-1'>
+            {hasPortfolioOriginText(portfolio.learnings) ? (
+              renderMarkdown(
+                portfolio.learnings,
+                correctionItem.learnings?.lines || [],
+                lessonsButton === '축소 또는 제외' ? 'reduce' : 'emphasize',
+              )
+            ) : (
+              <EmptyActivityOriginMessage />
             )}
           </div>
           <div className='w-[1px] flex-shrink-0 bg-[#9EA4A9]' />


### PR DESCRIPTION
## 연관 이슈
- Closes #242

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<img width="924" height="374" alt="image" src="https://github.com/user-attachments/assets/f00e8892-8406-43aa-bd76-d25c1b56cc07" />
첨삭 원문 미존재시 가이드 문구를 추가하였습니다.

<!-- 변경 사항 설명 -->

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-