### PR TITLE
[Fix/272] 인사이트 로그 스피너 전 에러 메세지 제거

### DIFF
--- a/src/app/(main)/log/LogClient.tsx
+++ b/src/app/(main)/log/LogClient.tsx
@@ -405,7 +405,7 @@ export default function LogClient() {
 
         {/* 카드 */}
         <div className='grid grid-cols-2 gap-[1.5rem]'>
-          {isLoggedIn && isLoading ? (
+          {isLoading ? (
             <div className='col-span-2 mt-[5rem] flex items-center justify-center'>
               <motion.div
                 animate={{ rotate: 720 }}

--- a/src/app/(main)/log/LogClientMobile.tsx
+++ b/src/app/(main)/log/LogClientMobile.tsx
@@ -9,7 +9,6 @@ import { useLogs } from '@/features/log/hooks/useLogs';
 import { useActivityTags } from '@/features/log/hooks/useActivityTags';
 import { MobileLogDetailView } from '@/features/log/components/mobile/MobileLogDetailView';
 import { type LogCardData } from '@/store/useLogStore';
-import { useAuthStore } from '@/store/useAuthStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { updateInsightLog, deleteInsightLog } from '@/services/insight';
 import { INSIGHTS_QUERY_KEY } from '@/features/log/constants';
@@ -30,8 +29,6 @@ import { MobileLogForm } from '@/features/log/components/mobile/MobileLogForm';
 
 export default function LogClientMobile() {
   const router = useRouter();
-  const accessToken = useAuthStore((s) => s.accessToken);
-  const isLoggedIn = accessToken != null;
   const queryClient = useQueryClient();
 
   const [searchInput, setSearchInput] = useState('');
@@ -224,7 +221,7 @@ export default function LogClientMobile() {
 
           {/* List */}
           <div className='flex flex-col gap-4'>
-            {isLoggedIn && isLoading ? (
+            {isLoading ? (
               <div className='mt-8 flex justify-center'>
                 <motion.div
                   animate={{ rotate: 720 }}

--- a/src/features/log/hooks/useLogs.ts
+++ b/src/features/log/hooks/useLogs.ts
@@ -38,10 +38,12 @@ export function useLogs(params: UseLogsParams = {}) {
   const sessionRestoreAttempted = useAuthStore(
     (s) => s.sessionRestoreAttempted,
   );
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const isLoggedIn = accessToken != null;
   const queryParams = toGetLogsParams(params);
   const {
     data = [],
-    isLoading,
+    isPending,
     refetch,
   } = useQuery({
     queryKey: [
@@ -54,5 +56,8 @@ export function useLogs(params: UseLogsParams = {}) {
     enabled: sessionRestoreAttempted,
   });
   const logCards: LogCardData[] = toLogCardDataList(data);
+  // 세션 복원 전·로그인 후 첫 fetch 전에는 빈 목록으로 오인하지 않도록 로딩 처리
+  const isLoading =
+    !sessionRestoreAttempted || (isLoggedIn && isPending);
   return { logCards, isLoading, refetch };
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #272 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
원인:컴포넌트에서 isLoggedIn && isLoading으로 스피너를 보여줬는데, isLoading은 세션 복원 전에는 false라서 로딩 중에도 에러 메세지가 먼저 랜더링 되었습니다.
해결:로딩 판단 로직을 useLogs 훅으로 옮기고, LogClient, LogClientMobile에는 useLogs가 반환하는 isLoading을 사용하도록 수정했습니다

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

