### PR TITLE
[Fix/277] 기업 분석 정보 글자수 제한 해제

### DIFF
--- a/src/features/correction/components/CorrectionAnalysisStep.tsx
+++ b/src/features/correction/components/CorrectionAnalysisStep.tsx
@@ -9,10 +9,7 @@ import {
   usePortfolioCorrectionControllerGetCompanyInsight,
 } from '@/api/endpoints/portfolio-correction/portfolio-correction';
 import { useEffect, useState } from 'react';
-import {
-  ANALYSIS_INFO_MAX_LENGTH,
-  EMPHASIS_POINTS_MAX_LENGTH,
-} from '@/features/correction/constants';
+import { EMPHASIS_POINTS_MAX_LENGTH } from '@/features/correction/constants';
 
 interface CorrectionAnalysisStepProps {
   correctionId?: string;
@@ -81,9 +78,7 @@ export function CorrectionAnalysisStep({
       companyInsightText &&
       analysisInfoValue === ''
     ) {
-      onAnalysisInfoChange(
-        limitAllowedInput(companyInsightText, ANALYSIS_INFO_MAX_LENGTH),
-      );
+      onAnalysisInfoChange(companyInsightText);
     }
   }, [
     enabled,
@@ -148,14 +143,7 @@ export function CorrectionAnalysisStep({
                   className='rounded-[1.25rem]'
                   minHeight='17.125rem'
                   value={analysisInfoValue}
-                  onChange={(val) => {
-                    onAnalysisInfoChange(
-                      limitAllowedInput(
-                        val,
-                        ANALYSIS_INFO_MAX_LENGTH,
-                      ),
-                    );
-                  }}
+                  onChange={onAnalysisInfoChange}
                 />
               </div>
             )}

--- a/src/features/correction/constants.ts
+++ b/src/features/correction/constants.ts
@@ -15,9 +15,6 @@ export const PDF_CATEGORY_NAMES: readonly PdfCategoryName[] = [
 /** PDF 카테고리당 글자 수 제한 */
 export const PDF_CATEGORY_CHAR_LIMIT = 400;
 
-/** 기업 분석 정보 최대 길이 */
-export const ANALYSIS_INFO_MAX_LENGTH = 1500;
-
 /** 강조 포인트 최대 길이 */
 export const EMPHASIS_POINTS_MAX_LENGTH = 200;
 


### PR DESCRIPTION
## 연관 이슈
- Closes #277

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
기업 분석 정보를 불러올 때 ANALYSIS_INFO_MAX_LENGTH로 1500자 제한이 적용되고 있었습니다. 이제 DB의 ompany_insight 전체가 표시됩니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-